### PR TITLE
clean up user creation

### DIFF
--- a/db/migrations/20190807062354_add_player_table.up.sql
+++ b/db/migrations/20190807062354_add_player_table.up.sql
@@ -1,9 +1,8 @@
 CREATE TABLE player (
     id SERIAL PRIMARY KEY,
     email VARCHAR(120) UNIQUE,
-    password VARCHAR(120),
-    name VARCHAR(100),
-    facebook_id VARCHAR(50) DEFAULT NULL,
+    password VARCHAR(200),
+    username VARCHAR(50) UNIQUE,
     token VARCHAR(200),
     status smallint DEFAULT 1,
     created_at TIMESTAMP DEFAULT (NOW() AT TIME ZONE 'PST'),

--- a/db/seed/player.sql
+++ b/db/seed/player.sql
@@ -1,2 +1,2 @@
-INSERT INTO player (email, password, name, status)
-VALUES ('tyler+first@geerydev.com', 'test', 'Tyler Geery', 1);
+INSERT INTO player (email, password, username, status)
+VALUES ('tyler+first@geerydev.com', 'test', 'tylertest', 1);

--- a/src/api_server/controllers/player.go
+++ b/src/api_server/controllers/player.go
@@ -21,7 +21,7 @@ func PlayerCreate(c *routing.Context) error {
 	}
 
 	// insert new player into DB
-	player, err := model.PlayerRegister(req.Email, req.Pw, req.Name, req.FacebookID)
+	player, err := model.PlayerRegister(req.Email, req.Pw, req.Username)
 	if err != nil {
 		return routing.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -37,6 +37,7 @@ func PlayerCreate(c *routing.Context) error {
 		Player: player,
 		Token:  token,
 	}
+	c.Response.WriteHeader(http.StatusCreated)
 
 	return c.Write(resp)
 }
@@ -83,8 +84,7 @@ func PlayerUpdate(c *routing.Context) error {
 	player := model.PlayerGetByID(authID)
 
 	player.Email = req.Email
-	player.Name = req.Name
-	player.FacebookID = req.FacebookID
+	player.Username = req.Username
 	err = player.Update()
 
 	if err != nil {

--- a/src/api_server/controllers/test/player_test.go
+++ b/src/api_server/controllers/test/player_test.go
@@ -36,7 +36,7 @@ func TestPlayerCreateFailures(t *testing.T) {
 				"email": "tyler@test.com",
 			},
 			http.StatusBadRequest,
-			"Invalid name: \n",
+			"Invalid username: \n",
 		},
 	}
 
@@ -55,7 +55,7 @@ func TestPlayerCreateFailures(t *testing.T) {
 // Tries to create player with re-used email
 func TestAttemptCreatePlayerAndCannotReuseEmail(t *testing.T) {
 	player := map[string]string{
-		"name":  "Test Player",
+		"username":  model.GetTestUsername("email-reuse"),
 		"pw":    "1234213kdsl;kdg",
 		"email": model.GetTestEmail("email-reuse"),
 	}
@@ -63,9 +63,9 @@ func TestAttemptCreatePlayerAndCannotReuseEmail(t *testing.T) {
 	body := strings.NewReader(string(playerEncoded))
 	resp := GetControllerResponse(t, "POST", "/v1/player/", body, map[string]string{"Content-Type": "application/json"})
 
-	test.ExpectEqualInt64s(t, int64(http.StatusOK), int64(resp.Result().StatusCode))
+	test.ExpectEqualInt64s(t, int64(http.StatusCreated), int64(resp.Result().StatusCode))
 
-	player["name"] = "Different Test Name"
+	player["username"] = "difftestname2"
 	playerEncoded, _ = json.Marshal(player)
 	body = strings.NewReader(string(playerEncoded))
 	resp = GetControllerResponse(t, "POST", "/v1/player/", body, map[string]string{"Content-Type": "application/json"})
@@ -77,9 +77,9 @@ func TestAttemptCreatePlayerAndCannotReuseEmail(t *testing.T) {
 
 func TestCreateUpdateAndDeletePlayer(t *testing.T) {
 	player := map[string]string{
-		"name":  "Test Player",
+		"username":  model.GetTestUsername("test-crud"),
 		"pw":    "1234213kdsl;kdg",
-		"email": model.GetTestEmail("email-reuse"),
+		"email": model.GetTestEmail("test-crud"),
 	}
 	playerEncoded, _ := json.Marshal(player)
 	body := strings.NewReader(string(playerEncoded))
@@ -89,9 +89,9 @@ func TestCreateUpdateAndDeletePlayer(t *testing.T) {
 	var createdPlayerResponse map[string]interface{}
 	_ = json.Unmarshal(createResponse, &createdPlayerResponse)
 
-	test.ExpectEqualInt64s(t, int64(http.StatusOK), int64(resp.Result().StatusCode))
+	test.ExpectEqualInt64s(t, int64(http.StatusCreated), int64(resp.Result().StatusCode))
 
-	player["name"] = "Different Test Name"
+	player["username"] = model.GetTestUsername("other-crud-name")
 	playerEncoded, _ = json.Marshal(player)
 	body = strings.NewReader(string(playerEncoded))
 	headers := map[string]string{"Content-Type": "application/json"}
@@ -103,7 +103,7 @@ func TestCreateUpdateAndDeletePlayer(t *testing.T) {
 	_ = json.Unmarshal(playerResponse, &updatedPlayer)
 
 	test.ExpectEqualInt64s(t, int64(http.StatusOK), int64(resp.Result().StatusCode))
-	test.ExpectEqualString(t, "Different Test Name", updatedPlayer.Name)
+	test.ExpectEqualString(t, player["username"], updatedPlayer.Username)
 
 	// Delete a player
 	headers = map[string]string{"Content-Type": "application/json"}
@@ -119,9 +119,9 @@ func TestCreateUpdateAndDeletePlayer(t *testing.T) {
 
 func TestResetPassword(t *testing.T) {
 	player := map[string]string{
-		"name":  "Test Player",
+		"username":  model.GetTestUsername("reset-password"),
 		"pw":    "1234213kdsl;kdg",
-		"email": model.GetTestEmail("email-reuse"),
+		"email": model.GetTestEmail("reset-password"),
 	}
 	playerEncoded, _ := json.Marshal(player)
 	body := strings.NewReader(string(playerEncoded))
@@ -131,7 +131,7 @@ func TestResetPassword(t *testing.T) {
 	var createdPlayerResponse map[string]interface{}
 	_ = json.Unmarshal(createResponse, &createdPlayerResponse)
 
-	test.ExpectEqualInt64s(t, int64(http.StatusOK), int64(resp.Result().StatusCode))
+	test.ExpectEqualInt64s(t, int64(http.StatusCreated), int64(resp.Result().StatusCode))
 
 	// TODO: reset password
 }

--- a/src/api_server/middleware/middleware_test.go
+++ b/src/api_server/middleware/middleware_test.go
@@ -24,7 +24,7 @@ func (t TestWriter) Header() http.Header {
 func TestLogRequestAndValidateToken(t *testing.T) {
 	count := 0
 	foundPlayerID := int64(0)
-	player := model.PlayerNew(34, "", "", "", "", "", model.PlayerStatusActive, "", "")
+	player := model.PlayerNew(34, "", "", "", "", model.PlayerStatusActive, "", "")
 	handler := func(c *routing.Context) error {
 		count++
 		foundPlayerID = c.Get("PlayerID").(int64)

--- a/src/api_server/requests/player.go
+++ b/src/api_server/requests/player.go
@@ -4,15 +4,13 @@ package requests
 type PlayerCreateRequest struct {
 	Email      string `json:"email"`
 	Pw         string `json:"pw"`
-	Name       string `json:"name"`
-	FacebookID string `json:"facebookID"`
+	Username       string `json:"username"`
 }
 
 // PlayerUpdateRequest - Request structure for PlayerUpdate request
 type PlayerUpdateRequest struct {
 	Email      string `json:"email"`
-	Name       string `json:"name"`
-	FacebookID string `json:"facebookID"`
+	Username       string `json:"username"`
 }
 
 // PlayerLoginRequest - Request structure for PlayerLogin request

--- a/src/auth/token_test.go
+++ b/src/auth/token_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCreatingAndExtractingToken(t *testing.T) {
 	var playerID int64 = 296
-	player := model.PlayerNew(playerID, "", "", "", "", "", model.PlayerStatusActive, "", "")
+	player := model.PlayerNew(playerID, "", "", "", "", model.PlayerStatusActive, "", "")
 	token, err := CreateToken(player)
 
 	if err != nil || token == "" {

--- a/src/model/player_test.go
+++ b/src/model/player_test.go
@@ -10,30 +10,30 @@ import (
 
 func TestPlayerRegisterFailures(t *testing.T) {
 	type TestCase struct {
-		args [4]string
+		args [3]string
 		err  error
 	}
 	testCases := []TestCase{
 		TestCase{
-			args: [4]string{"", "asdffdssadf", "", ""},
+			args: [3]string{"", "asdffdssadf", ""},
 			err:  errors.New("Invalid email format: "),
 		},
 		TestCase{
-			args: [4]string{"test", "asdffdssadf", "", ""},
+			args: [3]string{"test", "asdffdssadf", ""},
 			err:  errors.New("Invalid email format: test"),
 		},
 		TestCase{
-			args: [4]string{"test@yahoo.com", "1234", "", ""},
+			args: [3]string{"test@yahoo.com", "1234", ""},
 			err:  errors.New("Password must be at least 8 characters"),
 		},
 		TestCase{
-			args: [4]string{"tyger@geerydev.com", "test1234", "", ""},
-			err:  errors.New("Invalid name: "),
+			args: [3]string{"tyger@geerydev.com", "test1234", ""},
+			err:  errors.New("Invalid username: "),
 		},
 	}
 
 	for _, test := range testCases {
-		_, err := PlayerRegister(test.args[0], test.args[1], test.args[2], test.args[3])
+		_, err := PlayerRegister(test.args[0], test.args[1], test.args[2])
 
 		if err == nil || fmt.Sprintf("%s", err) != fmt.Sprintf("%s", test.err) {
 			t.Fatalf("Expected err: %s, received: %s", test.err, err)
@@ -43,19 +43,20 @@ func TestPlayerRegisterFailures(t *testing.T) {
 
 func TestPlayerRegisterSuccess(t *testing.T) {
 	type TestCase struct {
-		args   [4]string
+		args   [3]string
 		player *Player
 	}
 	testEmail := GetTestEmail("success")
+	testUsername := GetTestUsername("success")
 	testCases := []TestCase{
 		TestCase{
-			args:   [4]string{testEmail, "asdffdssadf", "jk", ""},
-			player: PlayerNew(0, testEmail, "asdffdssadf", "jk", "", "", PlayerStatusActive, "", ""),
+			args:   [3]string{testEmail, "asdffdssadf", testUsername},
+			player: PlayerNew(0, testEmail, "asdffdssadf", testUsername, "", PlayerStatusActive, "", ""),
 		},
 	}
 
 	for _, test := range testCases {
-		p, err := PlayerRegister(test.args[0], test.args[1], test.args[2], test.args[3])
+		p, err := PlayerRegister(test.args[0], test.args[1], test.args[2])
 
 		if p.ID <= 0 {
 			t.Fatalf("Received invalid player ID: %d, err: %s", p.ID, err)
@@ -67,17 +68,15 @@ func TestPlayerRegisterSuccess(t *testing.T) {
 		if p.pw == test.player.pw {
 			t.Fatalf("Expected hashed player pw for: %s, received: %s", test.player.pw, p.pw)
 		}
-		if p.Name != test.player.Name {
-			t.Fatalf("Expected player name: %s, received: %s", p.Name, test.player.Name)
-		}
-		if p.FacebookID != test.player.FacebookID {
-			t.Fatalf("Expected player FacebookID: %s, received: %s", p.FacebookID, test.player.FacebookID)
+		if p.Username != test.player.Username {
+			t.Fatalf("Expected player name: %s, received: %s", p.Username, test.player.Username)
 		}
 		if p.Status != test.player.Status {
 			t.Fatalf("Expected player status: %d, received: %d", p.Status, test.player.Status)
 		}
 
 		playerByEmail := PlayerGetByEmail(p.Email)
+		fmt.Println("playerByEmail: ", playerByEmail)
 		if playerByEmail.ID != p.ID {
 			t.Fatalf("PlayerByEmail does not have the correct ID: %d", playerByEmail.ID)
 		}
@@ -87,7 +86,10 @@ func TestPlayerRegisterSuccess(t *testing.T) {
 func TestPlayerLogin(t *testing.T) {
 	email := GetTestEmail("login")
 	password := "saklfsdlkfsa"
-	p, _ := PlayerRegister(email, password, "asdflksas TLkdlsff", "")
+	p, err := PlayerRegister(email, password, GetTestUsername("login"))
+	if err != nil {
+		t.Fatalf("Unexpected register err; %s", err)
+	}
 
 	p1, err := PlayerLogin(email, password)
 	if err != nil {
@@ -105,9 +107,9 @@ func TestPlayerLogin(t *testing.T) {
 }
 
 func TestPlayerUpdateError(t *testing.T) {
-	p := PlayerNew(0, "test@test.com", "", "", "", "", PlayerStatusActive, "", "")
+	p := PlayerNew(0, "test@test.com", "", "", "", PlayerStatusActive, "", "")
 
-	p.Name = "Tester"
+	p.Username = "Tester"
 	err := p.Update()
 
 	if err == nil || fmt.Sprintf("%s", err) != "Could not update non-existent player" {
@@ -116,12 +118,12 @@ func TestPlayerUpdateError(t *testing.T) {
 }
 
 func TestPlayerUpdate(t *testing.T) {
-	p, _ := PlayerRegister(GetTestEmail("update"), "saklfsdlkfsa", "asdflksas TLkdlsff", "")
+	p, _ := PlayerRegister(GetTestEmail("update"), "saklfsdlkfsa", GetTestUsername("update"))
 
-	p.Name = "Tester"
+	p.Username = GetTestUsername("update2")
 	err := p.Update()
 
 	if err != nil {
-		t.Fatalf("Unexpected register err; %s", err)
+		t.Fatalf("Unexpected update err; %s", err)
 	}
 }


### PR DESCRIPTION
- convert user `name` to `username`
  - adds `GetTestUsername` to help with creating unique usernames
- remove user `facebook_id`

Resolves #8 